### PR TITLE
data label for hub plugin definitions maintenance

### DIFF
--- a/labelsync.yml
+++ b/labelsync.yml
@@ -469,6 +469,7 @@ all_labels: &all_labels
   <<: *strategy
   <<: *valuestream
 
+
 ####################
 #   Repositories   #
 ####################

--- a/labelsync.yml
+++ b/labelsync.yml
@@ -302,7 +302,7 @@ data: &data
     color: "#FFBF00"
   "data/Product Dogfooding":
     color: "#FFFFFF"
-  "data/Hub Plugin Definitions":
+  "data/MeltanoHub Plugin Definitions":
     color: "#9400D3"
 
 leadership: &leadership

--- a/labelsync.yml
+++ b/labelsync.yml
@@ -302,6 +302,8 @@ data: &data
     color: "#FFBF00"
   "data/Product Dogfooding":
     color: "#FFFFFF"
+  "data/Hub Plugin Definitions":
+    color: "#9400D3"
 
 leadership: &leadership
   "designed alliance":


### PR DESCRIPTION
Last I heard it sounded like the idea is that moving forward we (the data team) will be responsible for reviewing plugin definition contributions, issues, etc on the hub in addition to potentially maintaining a pipeline that does it automatically (re: https://github.com/meltano/hub/issues/699). 

Theres a bunch of random issues like https://github.com/meltano/hub/issues/165 and https://github.com/meltano/hub/issues/518 that would be good to track separate from all the other hub issues related to front end work. 

@tayloramurphy what do you think about adding this label? I can also move it out of the data section into `common` if thats better.